### PR TITLE
Fixed issue causing two chains in one file to fail

### DIFF
--- a/langcorn/server/api.py
+++ b/langcorn/server/api.py
@@ -125,7 +125,7 @@ def create_service(*lc_apps, auth_token: str = "", app: FastAPI = None):
         inn, out = derive_fields(chain)
         logger.debug(f"inputs:{inn=}")
         logger.info(f"{lang_app=}:{chain.__class__.__name__}({inn})")
-        endpoint_prefix = lang_app.split(":")[0]
+        endpoint_prefix = lang_app.replace(":", '.')
         cls_name = "".join([c.capitalize() for c in endpoint_prefix.split(".")])
         request_cls = derive_class(cls_name, inn, add_memory=chain.memory)
         logger.debug(f"{request_cls=}")


### PR DESCRIPTION
When two chains are in one file, the chains are defined only to the module level, resulting in a KeyError. By including the chain variable name in the endpoint prefix, this resolves the issue.